### PR TITLE
Docker wait-for.sh

### DIFF
--- a/Docker-compose.yml
+++ b/Docker-compose.yml
@@ -16,6 +16,7 @@ services:
         build: .
         command:
             - "cd gobarber-backend"
+            - "sh -c './wait-for database:5432 -- yarn dev'"
             - "yarn typeorm migration:run"
             - "yarn dev"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ RUN ls
 
 EXPOSE 3333
 
-#RUN chmod 777 ./wait-for.sh
-#RUN ls -la
-#ENTRYPOINT ["./wait-for.sh","database:5432","--","yarn typeorm migration:run","yarn dev"]
+RUN chmod 777 ./wait-for.sh
+RUN ls -la
+# ENTRYPOINT ["./wait-for.sh","database:5432","--","yarn typeorm migration:run","yarn dev"]
+RUN [ "uptime" ]
+CMD [ "yarn dev" ]


### PR DESCRIPTION
@beauraines and I figured out a missing command on the docker-compose .yml. Thanks man!

Now the api service from the docker-compose.yml seems to be waiting for the database service to be ready.
Although there is a new issue totally disregarded of this one.

Closes #6 